### PR TITLE
feature/fix-plugins-scope

### DIFF
--- a/src/controller/projekktor.js
+++ b/src/controller/projekktor.js
@@ -928,12 +928,12 @@ window.projekktor = window.$p = (function (window, document, $) {
             for (var i = 0; i < plugins.length; i++) {
                 pluginName = "projekktor" + plugins[i].charAt(0).toUpperCase() + plugins[i].slice(1);
 
-                if (typeof window[pluginName] !== 'function') {
+                if (typeof window.projekktor[pluginName] !== 'function') {
                     alert("Projekktor Error: Plugin '" + plugins[i] + "' malicious or not available.");
                     continue;
                 }
 
-                pluginObj = $.extend(true, {}, new projekktorPluginInterface(), window[pluginName].prototype);
+                pluginObj = $.extend(true, {}, new projekktorPluginInterface(), window.projekktor[pluginName].prototype);
                 pluginObj.name = plugins[i].toLowerCase();
                 pluginObj.pp = this;
                 pluginObj.playerDom = this.env.playerDom;

--- a/src/plugins/projekktor.contextmenu.js
+++ b/src/plugins/projekktor.contextmenu.js
@@ -4,7 +4,7 @@
  * under GNU General Public License
  * http://www.projekktor.com/license/
  */
-var projekktorContextmenu = (function () {
+window.projekktorContextmenu = (function () {
 
     "use strict";
 

--- a/src/plugins/projekktor.contextmenu.js
+++ b/src/plugins/projekktor.contextmenu.js
@@ -4,7 +4,7 @@
  * under GNU General Public License
  * http://www.projekktor.com/license/
  */
-$p.projekktorContextmenu = (function () {
+window.projekktor.projekktorContextmenu = (function () {
 
     "use strict";
 

--- a/src/plugins/projekktor.contextmenu.js
+++ b/src/plugins/projekktor.contextmenu.js
@@ -4,7 +4,7 @@
  * under GNU General Public License
  * http://www.projekktor.com/license/
  */
-window.projekktorContextmenu = (function () {
+$p.projekktorContextmenu = (function () {
 
     "use strict";
 

--- a/src/plugins/projekktor.controlbar.js
+++ b/src/plugins/projekktor.controlbar.js
@@ -8,7 +8,7 @@
  * under GNU General Public License
  * http://www.projekktor.com/license/
  */
-$p.projekktorControlbar = (function () {
+window.projekktor.projekktorControlbar = (function () {
 
     "use strict";
 

--- a/src/plugins/projekktor.controlbar.js
+++ b/src/plugins/projekktor.controlbar.js
@@ -8,7 +8,7 @@
  * under GNU General Public License
  * http://www.projekktor.com/license/
  */
-var projekktorControlbar = (function () {
+window.projekktorControlbar = (function () {
 
     "use strict";
 

--- a/src/plugins/projekktor.controlbar.js
+++ b/src/plugins/projekktor.controlbar.js
@@ -8,7 +8,7 @@
  * under GNU General Public License
  * http://www.projekktor.com/license/
  */
-window.projekktorControlbar = (function () {
+$p.projekktorControlbar = (function () {
 
     "use strict";
 

--- a/src/plugins/projekktor.display.js
+++ b/src/plugins/projekktor.display.js
@@ -8,7 +8,7 @@
  * under GNU General Public License
  * http://www.projekktor.com/license/
  */
-$p.projekktorDisplay = (function () {
+window.projekktor.projekktorDisplay = (function () {
 
     "use strict";
 

--- a/src/plugins/projekktor.display.js
+++ b/src/plugins/projekktor.display.js
@@ -8,7 +8,7 @@
  * under GNU General Public License
  * http://www.projekktor.com/license/
  */
-var projekktorDisplay = (function () {
+window.projekktorDisplay = (function () {
 
     "use strict";
 

--- a/src/plugins/projekktor.display.js
+++ b/src/plugins/projekktor.display.js
@@ -8,7 +8,7 @@
  * under GNU General Public License
  * http://www.projekktor.com/license/
  */
-window.projekktorDisplay = (function () {
+$p.projekktorDisplay = (function () {
 
     "use strict";
 

--- a/src/plugins/projekktor.rss.js
+++ b/src/plugins/projekktor.rss.js
@@ -4,7 +4,7 @@
  * under GNU General Public License
  * http://www.projekktor.com/license/
  */
-window.projekktorRSS = (function () {
+$p.projekktorRSS = (function () {
 
     "use strict";
 

--- a/src/plugins/projekktor.rss.js
+++ b/src/plugins/projekktor.rss.js
@@ -4,7 +4,7 @@
  * under GNU General Public License
  * http://www.projekktor.com/license/
  */
-var projekktorRSS = (function () {
+window.projekktorRSS = (function () {
 
     "use strict";
 

--- a/src/plugins/projekktor.rss.js
+++ b/src/plugins/projekktor.rss.js
@@ -4,7 +4,7 @@
  * under GNU General Public License
  * http://www.projekktor.com/license/
  */
-$p.projekktorRSS = (function () {
+window.projekktor.projekktorRSS = (function () {
 
     "use strict";
 

--- a/src/plugins/projekktor.settings.js
+++ b/src/plugins/projekktor.settings.js
@@ -4,7 +4,7 @@
  * under GNU General Public License
  * http://www.projekktor.com/license/
  */
-$p.projekktorSettings = (function () {
+window.projekktor.projekktorSettings = (function () {
 
     "use strict";
 

--- a/src/plugins/projekktor.settings.js
+++ b/src/plugins/projekktor.settings.js
@@ -4,7 +4,7 @@
  * under GNU General Public License
  * http://www.projekktor.com/license/
  */
-window.projekktorSettings = (function () {
+$p.projekktorSettings = (function () {
 
     "use strict";
 

--- a/src/plugins/projekktor.settings.js
+++ b/src/plugins/projekktor.settings.js
@@ -4,7 +4,7 @@
  * under GNU General Public License
  * http://www.projekktor.com/license/
  */
-var projekktorSettings = (function () {
+window.projekktorSettings = (function () {
 
     "use strict";
 


### PR DESCRIPTION
Explicitly assigned all plugins to `window`, as `projekktor._registerPlugins()` looks for them in the `window` scope. This solves `plugin not found` errors when using projekktor with angular application.